### PR TITLE
Created & tested delete show action

### DIFF
--- a/scripts/create-show.sh
+++ b/scripts/create-show.sh
@@ -9,10 +9,10 @@ curl "${API}${URL_PATH}" \
   --header "Authorization: Token token=BAhJIiU1NzA2YzkwMmVkYzdjZjE1NjJlYjFhOTRlYzY3MjY2OAY6BkVG--3d6cc8ddd358efddeea673805508e116e7c7dd65" \
   --data '{
     "show": {
-      "show_name": "Bark and Byte: Digital Tree Bark Art",
-      "show_date": "2017-11-22",
-      "show_time": "19:30",
-      "notes": "This was a great show. Fabulous tree bark textures."
+      "show_name": "Caravaggio",
+      "show_date": "2017-07-28",
+      "show_time": "17:00",
+      "notes": "Traveling show MFA."
     }
   }'
 

--- a/scripts/delete-show.sh
+++ b/scripts/delete-show.sh
@@ -1,0 +1,13 @@
+
+# run at command line by going to /scripts
+# then typing sh delete-show.sh and pressing return
+# the ID on line 8 must be the id of an existing show item in the DB
+
+API="${API_ORIGIN:-http://localhost:4741}"
+URL_PATH="/shows/"
+ID="5"
+curl "${API}${URL_PATH}${ID}" \
+--include \
+--request DELETE \
+--header "Content-Type: application/json" \
+--header "Authorization: Token token=BAhJIiU1NzA2YzkwMmVkYzdjZjE1NjJlYjFhOTRlYzY3MjY2OAY6BkVG--3d6cc8ddd358efddeea673805508e116e7c7dd65" \


### PR DESCRIPTION
Modified create-show.sh to add a few more shows to database

Created delete-show.sh to test the destroy-show controller action we
created in /controllers/shows_controller.rb:

```
def destroy
  @show.destroy
end
```

Running scripts/delete-show.sh at command line (by changing into
the /scripts directory and typing `sh show-destroy.sh`) deletes
the show with the ID number indicated in the curl script and
returns 204 No Content from the API. Confirmed that show record
is no longer in DB after curl script to delete it is run.

Closes Issue #10.