### PR TITLE
Ran migration file to create `artists` table in database

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170718184729) do
+ActiveRecord::Schema.define(version: 20170719200928) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "artists", force: :cascade do |t|
+    t.string   "artist_name"
+    t.string   "artist_website"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+  end
 
   create_table "examples", force: :cascade do |t|
     t.text     "text",       null: false


### PR DESCRIPTION
Ran `bin/rails migrate:db`

The migration file ran and modified the schema, adding:

```
create_table "artists", force: :cascade do |t|
  t.string   "artist_name"
  t.string   "artist_website"
  t.datetime "created_at",     null: false
  t.datetime "updated_at",     null: false
end
```

Confirmed that table `artists` was present in the database.

Closes Issue #27