### PR TITLE
Created foreign key reference between `artists` and `shows`

### DIFF
--- a/db/migrate/20170719204606_add_artist_to_shows.rb
+++ b/db/migrate/20170719204606_add_artist_to_shows.rb
@@ -1,0 +1,5 @@
+class AddArtistToShows < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :shows, :artist, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170719200928) do
+ActiveRecord::Schema.define(version: 20170719204606) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,8 @@ ActiveRecord::Schema.define(version: 20170719200928) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer  "user_id"
+    t.integer  "artist_id"
+    t.index ["artist_id"], name: "index_shows_on_artist_id", using: :btree
     t.index ["user_id"], name: "index_shows_on_user_id", using: :btree
   end
 
@@ -52,5 +54,6 @@ ActiveRecord::Schema.define(version: 20170719200928) do
   end
 
   add_foreign_key "examples", "users"
+  add_foreign_key "shows", "artists"
   add_foreign_key "shows", "users"
 end


### PR DESCRIPTION
Ran ` bin/rails generate migration AddArtistToShows artist:references`
and generated migration file.

Ran 'bin/rails migrate:db', which updated db/schema.rb as follows:

```
create_table "shows", force: :cascade do |t|
  t.string   "show_name"
  t.date     "show_date"
  t.time     "show_time"
  t.text     "notes"
  t.datetime "created_at", null: false
  t.datetime "updated_at", null: false
  t.integer  "user_id"
  t.integer  "artist_id"
  t.index ["artist_id"], name: "index_shows_on_artist_id", using: :btree
  t.index ["user_id"], name: "index_shows_on_user_id", using: :btree
end
```
Confirmed in db that `shows` table in db now has a column named `artist_id`.

Closes Issue #30